### PR TITLE
xdelta3.c: fix for clang 16

### DIFF
--- a/xdelta3/xdelta3.c
+++ b/xdelta3/xdelta3.c
@@ -3466,7 +3466,7 @@ xd3_process_stream_cancelable (int            is_encode,
 
 static int
 xd3_process_memory_enhanced (int            is_encode,
-		    int          (*func) (xd3_stream *),
+		    int          (*func) (xd3_stream *, uint8_t *),
 		    const uint8_t *input,
 		    usize_t        input_size,
 		    const uint8_t *source,
@@ -3545,7 +3545,7 @@ xd3_process_memory_enhanced (int            is_encode,
 
 static int
 xd3_process_memory (int            is_encode,
-		    int          (*func) (xd3_stream *),
+		    int          (*func) (xd3_stream *, uint8_t *),
 		    const uint8_t *input,
 		    usize_t        input_size,
 		    const uint8_t *source,
@@ -3555,6 +3555,7 @@ xd3_process_memory (int            is_encode,
 		    usize_t        output_size_max,
 		    int            flags) 
 {
+  uint8_t cancellationRequest = 0;
   return xd3_process_memory_enhanced (is_encode,
 		    func,
 		    input,
@@ -3565,7 +3566,7 @@ xd3_process_memory (int            is_encode,
 		    output_size,
 		    output_size_max,
 		    flags,
-        0,
+        &cancellationRequest,
         0);
 }
 
@@ -3591,7 +3592,7 @@ xd3_decode_memory (const uint8_t *input,
 		   usize_t       *output_size,
 		   usize_t        output_size_max,
 		   int            flags) {
-  return xd3_process_memory (0, & xd3_decode_input,
+  return xd3_process_memory (0, xd3_decode_input_cancelable,
 			     input, input_size,
 			     source, source_size,
 			     output, output_size, output_size_max,
@@ -3622,7 +3623,7 @@ xd3_encode_memory (const uint8_t *input,
 		   usize_t        *output_size,
 		   usize_t        output_size_max,
 		   int            flags) {
-  return xd3_process_memory (1, & xd3_encode_input,
+  return xd3_process_memory (1, xd3_encode_input_cancelable,
 			     input, input_size,
 			     source, source_size,
 			     output, output_size, output_size_max,
@@ -3640,7 +3641,7 @@ xd3_encode_memory_enhanced (const uint8_t *input,
 		   int            flags,
 		   uint8_t       *cancellationRequested,
        xd3_smatch_cfg stringMatcher) {
-  return xd3_process_memory_enhanced (1, & xd3_encode_input_cancelable,
+  return xd3_process_memory_enhanced (1, xd3_encode_input_cancelable,
 			     input, input_size,
 			     source, source_size,
 			     output, output_size, output_size_max,


### PR DESCRIPTION
Pass cancelable functions where they are expected which fixes building with -Wincompatible-function-pointer-types